### PR TITLE
Force to use attributed text

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: objective-c
 before_install:
 - gem install cocoapods
-
-# Use when you don't have third party dependencies
-script: xctool -project Pod/Pod.xcodeproj -scheme Tests -sdk iphonesimulator build test
-
-# Use when you have third party dependencies (CocoaPods generates a workspace)
-# podfile: Pod/Podfile
-# script: xctool -workspace Pod/Pod.xcworkspace -scheme Tests -sdk iphonesimulator build test
+podfile: Pod/Podfile
+script: xctool -workspace Pod/Pod.xcworkspace -scheme Tests -sdk iphonesimulator build test

--- a/Pod/Demo/AppDelegate.swift
+++ b/Pod/Demo/AppDelegate.swift
@@ -46,30 +46,44 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       tutorialController.navigationItem.leftBarButtonItem = leftButton
       tutorialController.navigationItem.rightBarButtonItem = rightButton
 
+      let font = UIFont(name: "ArialRoundedMTBold", size: 42.0)!
+      let color = UIColor.whiteColor()
+      let attributes = [NSFontAttributeName: font, NSForegroundColorAttributeName: color];
+
       let model1 = TutorialModel(
         title: "Tutorial on how to make a profit",
         text: nil,
         image: nil)
+      model1.setTitleAttributes(attributes)
+      model1.setTextAttributes(attributes)
 
       let model2 = TutorialModel(
         title: "Step I",
         text: "Collect underpants\n💭",
         image: nil)
+      model2.setTitleAttributes(attributes)
+      model2.setTextAttributes(attributes)
 
       let model3 = TutorialModel(
         title: "Step II",
         text: "🎅🎅🏻🎅🏼🎅🏽🎅🏾🎅🏿",
         image: nil)
+      model3.setTitleAttributes(attributes)
+      model3.setTextAttributes(attributes)
 
       let model4 = TutorialModel(
         title: "Step III",
         text: "Profit\n💸",
         image: nil)
+      model4.setTitleAttributes(attributes)
+      model4.setTextAttributes(attributes)
 
       let model5 = TutorialModel(
         title: nil,
         text: "Thanks for your time.",
         image:UIImage(named: "hyper-logo.png"))
+      model5.setTitleAttributes(attributes)
+      model5.setTextAttributes(attributes)
 
       let page1 = UIViewController(model: model1)
       let page2 = UIViewController(model: model2)
@@ -78,13 +92,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       let page5 = UIViewController(model: model5)
 
       tutorialController.add([page1, page2, page3, page4, page5])
-
-      let font = UIFont(name: "ArialRoundedMTBold", size: 42.0)!
-      TutorialController.setTitleFont(font)
-      TutorialController.setTextFont(font)
-
-      TutorialController.setTitleColor(UIColor.whiteColor())
-      TutorialController.setTextColor(UIColor.whiteColor())
 
       window = UIWindow(frame: UIScreen.mainScreen().bounds)
       window?.rootViewController = navigationController

--- a/Pod/Demo/AppDelegate.swift
+++ b/Pod/Demo/AppDelegate.swift
@@ -48,7 +48,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
       let font = UIFont(name: "ArialRoundedMTBold", size: 42.0)!
       let color = UIColor.whiteColor()
-      let attributes = [NSFontAttributeName: font, NSForegroundColorAttributeName: color];
+      let paragraphStyle = NSMutableParagraphStyle()
+      paragraphStyle.alignment = NSTextAlignment.Center
+
+      let attributes = [NSFontAttributeName: font, NSForegroundColorAttributeName: color,
+        NSParagraphStyleAttributeName: paragraphStyle]
 
       let model1 = TutorialModel(
         title: "Tutorial on how to make a profit",

--- a/Pod/Tests/Specs/TutorialModelSpec.swift
+++ b/Pod/Tests/Specs/TutorialModelSpec.swift
@@ -7,14 +7,14 @@ class TutorialModelSpec: QuickSpec {
     describe("TutorialModel") {
       var model: TutorialModel!
 
-      describe("#init") {
-        beforeEach {
-          model = TutorialModel(
-            title: "Step I",
-            text: "Collect underpants",
-            image: dummyImage())
-        }
+      beforeEach {
+        model = TutorialModel(
+          title: "Step I",
+          text: "Collect underpants",
+          image: dummyImage())
+      }
 
+      describe("#init") {
         it("sets title to titleLabel") {
           expect(model.titleLabel.text).to(equal(model.title))
         }
@@ -25,6 +25,28 @@ class TutorialModelSpec: QuickSpec {
 
         it("sets image to imageView") {
           expect(model.imageView.image).to(equal(model.image))
+        }
+      }
+
+      describe("#setTitleAttributes") {
+         it("sets attributes to titleLabel") {
+          let attributes = [NSForegroundColorAttributeName: UIColor.whiteColor(),
+            NSFontAttributeName: UIFont.systemFontOfSize(14.0)]
+          let string = NSAttributedString(string: model.title!, attributes: attributes)
+
+          model.setTitleAttributes(attributes)
+          expect(model.titleLabel.attributedText).to(equal(string))
+        }
+      }
+
+      describe("#setTextAttributes") {
+        it("sets attributes to textView") {
+          let attributes = [NSForegroundColorAttributeName: UIColor.whiteColor(),
+            NSFontAttributeName: UIFont.systemFontOfSize(14.0)]
+          let string = NSAttributedString(string: model.text!, attributes: attributes)
+
+          model.setTextAttributes(attributes)
+          expect(model.textView.attributedText).to(equal(string))
         }
       }
 

--- a/Source/TutorialController.swift
+++ b/Source/TutorialController.swift
@@ -16,24 +16,6 @@ public class TutorialController: PagesController {
   override public func add(viewControllers: [UIViewController]) {
     super.add(viewControllers)
   }
-
-  // MARK: UIAppearance
-
-  public static func setTitleFont(font: UIFont) {
-    UILabel.appearance().font = font
-  }
-
-  public static func setTextFont(font: UIFont) {
-    UITextView.appearance().font = font
-  }
-
-  public static func setTitleColor(color: UIColor) {
-    UILabel.appearance().textColor = color
-  }
-
-  public static func setTextColor(color: UIColor) {
-    UITextView.appearance().textColor = color
-  }
 }
 
 public extension UIViewController {
@@ -50,7 +32,7 @@ public extension UIViewController {
     for modelView in modelViews {
       view.addSubview(modelView)
     }
-    
+
     model.layoutSubviews()
   }
 }

--- a/Source/TutorialModel.swift
+++ b/Source/TutorialModel.swift
@@ -20,18 +20,28 @@ import Cartography
 
   public var title: String? {
     get {
-      return titleLabel.text
+      return titleLabel.attributedText.string
     }
     set {
-      titleLabel.text = newValue
+      let text = newValue != nil ? newValue! : ""
+      let range = NSMakeRange(0, titleLabel.attributedText.length)
+      let string = titleLabel.attributedText.mutableCopy() as! NSMutableAttributedString
+      string.replaceCharactersInRange(range, withString: text)
+
+      titleLabel.attributedText = string
     }
   }
   public var text: String? {
     get {
-      return textView.text.isEmpty ? nil : textView.text
+      return textView.attributedText.string.isEmpty ? nil : textView.attributedText.string
     }
     set {
-      textView.text = newValue
+      let text = newValue != nil ? newValue! : ""
+      let range = NSMakeRange(0, textView.attributedText.length)
+      let string = textView.attributedText.mutableCopy() as! NSMutableAttributedString
+      string.replaceCharactersInRange(range, withString: text)
+
+      textView.attributedText = string
     }
   }
 
@@ -44,7 +54,7 @@ import Cartography
     let label = UILabel(frame: CGRectNull)
 
     label.numberOfLines = 1
-    label.textAlignment = .Center
+    label.attributedText = NSAttributedString(string: "")
 
     return label
     }()
@@ -52,8 +62,8 @@ import Cartography
   lazy private(set) var textView: UITextView = {
     let textView = UITextView(frame: CGRectNull)
 
-    textView.textAlignment = .Center
     textView.backgroundColor = UIColor.clearColor()
+    textView.attributedText = NSAttributedString(string: "")
 
     return textView
     }()
@@ -72,13 +82,12 @@ import Cartography
 extension TutorialModel {
 
   public func setTitleAttributes(attributes: [String: AnyObject]) {
-    if let text = titleLabel.text {
-      titleLabel.attributedText = NSAttributedString(string: text, attributes: attributes)
-    }
+    var text = titleLabel.attributedText.string
+    titleLabel.attributedText = NSAttributedString(string: text, attributes: attributes)
   }
 
   public func setTextAttributes(attributes: [String: AnyObject]) {
-    let text = textView.text
+    var text = textView.attributedText.string
     textView.attributedText = NSAttributedString(string: text, attributes: attributes)
   }
 }

--- a/Source/TutorialModel.swift
+++ b/Source/TutorialModel.swift
@@ -7,7 +7,7 @@ import Cartography
     static let minimumMarginSpace: CGFloat = 20.0
   }
 
-  // MARK: Public methods
+  // MARK: Public properties
 
   public var image: UIImage? {
     get {
@@ -64,6 +64,22 @@ import Cartography
     self.image = image
     self.title = title
     self.text = text
+  }
+}
+
+// MARK: Styling
+
+extension TutorialModel {
+
+  public func setTitleAttributes(attributes: [String: AnyObject]) {
+    if let text = titleLabel.text {
+      titleLabel.attributedText = NSAttributedString(string: text, attributes: attributes)
+    }
+  }
+
+  public func setTextAttributes(attributes: [String: AnyObject]) {
+    let text = textView.text
+    textView.attributedText = NSAttributedString(string: text, attributes: attributes)
   }
 }
 


### PR DESCRIPTION
While testing I've discovered that setting style attributes via `UILabel.appearance()` doesn't always work as expected. That's why I've decided to add support of `NSAttributedString` that makes it even more customisable. Now it's possible to set any attributes you want both for title and text in any model.